### PR TITLE
fix: accessibility polish and blog breadcrumb navigation

### DIFF
--- a/app/blogs/post/[id]/page.tsx
+++ b/app/blogs/post/[id]/page.tsx
@@ -8,6 +8,7 @@ import { atomDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { ExtraProps } from 'react-markdown'
 import { FiHash } from 'react-icons/fi'
 import PostAvatarDateComponent from '@/app/components/PostAvatarDateComponent'
+import BlogBreadcrumb from '@/app/components/BlogBreadcrumb'
 import { Post } from '@/app/types';
 import { getPostData, getAllPostIds } from '@/lib/posts';
 import { BASE_URL } from '@/app/constants';
@@ -93,6 +94,7 @@ export default async function PostPage({params}: Props) {
     return (
       <section className="flex flex-col min-h-screen w-full p-8 items-center">
         <div className='flex flex-col w-full md:w-5/6 lg:w-3/6 '>
+        <BlogBreadcrumb title={postData.title} />
         <h1 className={'text-foreground/90 font-extrabold text-3xl mb-1'}>{postData.title}</h1>
         <h3 className='text-foreground/80 font-medium text-xl mb-4'>{postData.description}</h3>  
         <PostAvatarDateComponent 

--- a/app/components/BlogBreadcrumb.tsx
+++ b/app/components/BlogBreadcrumb.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { BreadcrumbItem, Breadcrumbs } from '@heroui/react'
+
+export default function BlogBreadcrumb({ title }: { title: string }) {
+  return (
+    <Breadcrumbs className='mb-4' size='lg'>
+      <BreadcrumbItem href='/'>Home</BreadcrumbItem>
+      <BreadcrumbItem href='/blogs'>Blogs</BreadcrumbItem>
+      <BreadcrumbItem isCurrent>{title}</BreadcrumbItem>
+    </Breadcrumbs>
+  )
+}

--- a/app/components/FooterComponent.tsx
+++ b/app/components/FooterComponent.tsx
@@ -3,7 +3,7 @@ import { Link } from "@heroui/react";
 
 export default function FooterComponent() {
   return (
-    <footer className="relative bottom-0 left-0 z-40 flex justify-center p-2 items-center w-full h-auto border-t border-divider">
+    <footer className="relative bottom-0 left-0 z-40 flex justify-center p-4 items-center w-full h-auto border-t border-divider">
       <p className="text-center text-sm font-regular text-foreground-500">
         Designed with ❤️ by{" "}
         <Link className={"text-primary-500"} underline="hover" href="/">

--- a/app/components/NavbarComponent.tsx
+++ b/app/components/NavbarComponent.tsx
@@ -21,7 +21,8 @@ export default function NavbarComponent() {
   const pathname = usePathname();
 
   const isActivePath = (href: string) => {
-    return href === pathname;
+    if (href === "/") return pathname === "/";
+    return pathname.startsWith(href);
   };
 
   const navItems = [

--- a/app/components/ThemeSwitch.tsx
+++ b/app/components/ThemeSwitch.tsx
@@ -14,11 +14,11 @@ export default function ThemeSwitch() {
     if (!mounted) return <FiLoader className="w-6 h-6 text-slate-400" role="img" aria-label="Loading theme"/>
 
     if(theme === 'dark') {
-        return <FiSun onClick={() => setTheme('light')} className="w-6 h-6 text-amber-500 cursor-pointer" role="button" aria-label="Switch to light theme" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && setTheme('light')}/>
+        return <FiSun onClick={() => setTheme('light')} className="w-6 h-6 text-amber-500 cursor-pointer" role="button" aria-label="Switch to light theme" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setTheme('light')}/>
     }
 
     if(theme === 'light') {
-        return <FiMoon onClick={() => setTheme('dark')} className="w-6 h-6 text-slate-900 cursor-pointer" role="button" aria-label="Switch to dark theme" tabIndex={0} onKeyDown={(e) => e.key === 'Enter' && setTheme('dark')}/>
+        return <FiMoon onClick={() => setTheme('dark')} className="w-6 h-6 text-slate-900 cursor-pointer" role="button" aria-label="Switch to dark theme" tabIndex={0} onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setTheme('dark')}/>
     }
 
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,11 +37,32 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={inter.className}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Person',
+              name: 'Shubham Singh',
+              url: BASE_URL,
+              jobTitle: 'Software Engineer',
+              knowsAbout: ['Android', 'Kotlin', 'Jetpack Compose', 'React', 'TypeScript'],
+              sameAs: [
+                'https://github.com/ishubhamsingh',
+              ],
+            }),
+          }}
+        />
+        <a href="#main-content" className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground">
+          Skip to content
+        </a>
         <Providers>
-        <SnowfallComponent />  
+        <SnowfallComponent />
         <Navbar />
         <WebVitals />
+        <main id="main-content">
         {children}
+        </main>
         <Footer />
         </Providers>
         <Analytics />


### PR DESCRIPTION
## Summary
- Add breadcrumb navigation (Home > Blogs > Post Title) to blog post pages for easier back-navigation
- Highlight the "Blogs" navbar tab when viewing blog post pages using `startsWith` route matching
- Add accessibility improvements and structured data (from prior commit)

## Test plan
- [ ] Verify breadcrumb appears on blog post pages with correct links
- [ ] Verify "Blogs" navbar tab is highlighted on `/blogs` and `/blogs/post/*` routes
- [ ] Verify "Home" tab is only highlighted on `/` (no false positives)
- [ ] Verify other nav tabs (Resume, Uses) still highlight correctly on their pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)