### PR TITLE
feat: add breadcrumb navigation to blog post pages

### DIFF
--- a/app/blogs/post/[id]/page.tsx
+++ b/app/blogs/post/[id]/page.tsx
@@ -8,6 +8,7 @@ import { atomDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import type { ExtraProps } from 'react-markdown'
 import { FiHash } from 'react-icons/fi'
 import PostAvatarDateComponent from '@/app/components/PostAvatarDateComponent'
+import BlogBreadcrumb from '@/app/components/BlogBreadcrumb'
 import { Post } from '@/app/types';
 import { getPostData, getAllPostIds } from '@/lib/posts';
 import { BASE_URL } from '@/app/constants';
@@ -93,6 +94,7 @@ export default async function PostPage({params}: Props) {
     return (
       <section className="flex flex-col min-h-screen w-full p-8 items-center">
         <div className='flex flex-col w-full md:w-5/6 lg:w-3/6 '>
+        <BlogBreadcrumb title={postData.title} />
         <h1 className={'text-foreground/90 font-extrabold text-3xl mb-1'}>{postData.title}</h1>
         <h3 className='text-foreground/80 font-medium text-xl mb-4'>{postData.description}</h3>  
         <PostAvatarDateComponent 

--- a/app/components/BlogBreadcrumb.tsx
+++ b/app/components/BlogBreadcrumb.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { BreadcrumbItem, Breadcrumbs } from '@heroui/react'
+
+export default function BlogBreadcrumb({ title }: { title: string }) {
+  return (
+    <Breadcrumbs className='mb-4' size='lg'>
+      <BreadcrumbItem href='/'>Home</BreadcrumbItem>
+      <BreadcrumbItem href='/blogs'>Blogs</BreadcrumbItem>
+      <BreadcrumbItem isCurrent>{title}</BreadcrumbItem>
+    </Breadcrumbs>
+  )
+}

--- a/app/components/NavbarComponent.tsx
+++ b/app/components/NavbarComponent.tsx
@@ -21,7 +21,8 @@ export default function NavbarComponent() {
   const pathname = usePathname();
 
   const isActivePath = (href: string) => {
-    return href === pathname;
+    if (href === "/") return pathname === "/";
+    return pathname.startsWith(href);
   };
 
   const navItems = [


### PR DESCRIPTION
## Summary
- Add breadcrumb navigation (Home > Blogs > Post Title) to blog post pages for easier back-navigation
- Highlight the "Blogs" navbar tab on blog post pages using `startsWith` route matching instead of exact match

## Test plan
- [ ] Verify breadcrumb appears on blog post pages with correct links
- [ ] Verify "Blogs" navbar tab is highlighted on `/blogs` and `/blogs/post/*` routes
- [ ] Verify "Home" tab is only highlighted on `/` (no false positives)
- [ ] Verify other nav tabs (Resume, Uses) still highlight correctly on their pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)