### PR TITLE
fix(layout): hold up on 4K and on phones

### DIFF
--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -46,8 +46,8 @@ export default function BlogPage() {
     }, [debouncedQuery]);
 
     return (
-       <section className="flex p-8 mx-auto flex-col min-h-screen items-center">
-        <div className='w-full md:w-5/6 lg:w-4/6'>
+       <section className="flex px-4 py-8 sm:p-8 mx-auto flex-col min-h-screen items-center">
+        <div className='w-full md:w-5/6 lg:w-4/6 max-w-[1536px]'>
         <div className='flex flex-col gap-8 mb-24 items-center justify-start md:flex-row md:justify-between sm:flex-row sm:justify-between'>
         <p className="text-4xl font-bold text-start">Blogs</p>
          <Input
@@ -60,7 +60,7 @@ export default function BlogPage() {
          onValueChange={handleSearchChange}
          startContent={<FiSearch />}
          isClearable
-         className='max-w-unit-6xl'/> 
+         className='w-full sm:max-w-xs'/>
         </div>
        <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 gap-x-6 gap-y-8'>
           {searchQuery !== "" && data.length === 0 && 

--- a/app/blogs/post/[id]/blog.css
+++ b/app/blogs/post/[id]/blog.css
@@ -80,20 +80,25 @@ table.default {
     unicode-bidi: isolate;
 }
 
-/* Phone screenshots from GitHub — cap at phone width */
-img[src*="raw.githubusercontent.com"] {
-    max-width: 320px;
+/* Screenshots are centred and capped so they never dominate the column.
+   The cap is min(px, 100%) rather than a bare pixel value: on a narrow phone
+   the fixed width alone is wider than the available column and the image
+   spills past the right edge of the viewport. */
+img[src*="raw.githubusercontent.com"],
+img[src*="-widget-"] {
     display: block;
+    height: auto;
     margin-left: auto;
     margin-right: auto;
     border-radius: 1rem;
 }
 
+/* Tall phone screenshots: cap at roughly phone width */
+img[src*="raw.githubusercontent.com"] {
+    max-width: min(320px, 100%);
+}
+
 /* Widget shots are cropped closer to square, so they can take a little more room */
 img[src*="-widget-"] {
-    max-width: 420px;
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-    border-radius: 1rem;
+    max-width: min(420px, 100%);
 }

--- a/app/blogs/post/[id]/page.tsx
+++ b/app/blogs/post/[id]/page.tsx
@@ -106,8 +106,8 @@ export default async function PostPage({params}: Props) {
   const { id } = await params
   const postData = await fetchPostData(id)
     return (
-      <section className="flex flex-col min-h-screen w-full p-8 items-center">
-        <div className='flex flex-col w-full md:w-5/6 lg:w-3/6 '>
+      <section className="flex flex-col min-h-screen w-full px-4 py-8 sm:p-8 items-center">
+        <div className='flex flex-col w-full md:w-5/6 lg:w-3/6 max-w-3xl'>
         <BlogBreadcrumb title={postData.title} />
         <h1 className={'text-foreground/90 font-extrabold text-3xl mb-1'}>{postData.title}</h1>
         <h3 className='text-foreground/80 font-medium text-xl mb-4'>{postData.description}</h3>  
@@ -145,7 +145,7 @@ export default async function PostPage({params}: Props) {
           <ReactMarkdown 
           remarkPlugins={[remarkGfm]}
           rehypePlugins={[[addClasses, addClassesOptions]]}
-          className={'flex p-8 mx-auto flex-col w-full'}
+          className={'flex px-0 py-8 sm:p-8 mx-auto flex-col w-full min-w-0'}
           components={{
             code: CodeBlock,
             p: CustomParagraph

--- a/app/components/AboutComponent.tsx
+++ b/app/components/AboutComponent.tsx
@@ -36,16 +36,16 @@ const contactLinks = [
 export default function AboutComponent() {
   return (
     <section className="flex flex-col justify-center items-center gap-8 p-8 w-full">
-      <div className="flex flex-col gap-4 justify-center">
+      <div className="flex w-full max-w-[1536px] flex-col gap-4 justify-center">
         <p className="text-4xl font-bold my-8 text-center">About</p>
-        <div className="flex flex-col md:flex-row gap-8 items-center justify-center">
+        <div className="flex flex-col md:flex-row gap-12 items-center justify-center">
           <Image
             src={AboutImage}
-            className={"size-4/6 md:size-2/6"}
+            className={"w-full max-w-sm md:max-w-md h-auto"}
             alt="Illustration of a developer working"
             placeholder={"empty"}
             />
-        <div className="flex flex-col gap-4 justify-center">  
+        <div className="flex max-w-2xl flex-col gap-4 justify-center">
         <p className="text-2xl font-medium text-foreground text-start">
           I am a computer science engineering graduate, with around 8 years of
           working experience.

--- a/app/components/BlogBreadcrumb.tsx
+++ b/app/components/BlogBreadcrumb.tsx
@@ -4,10 +4,20 @@ import { BreadcrumbItem, Breadcrumbs } from '@heroui/react'
 
 export default function BlogBreadcrumb({ title }: { title: string }) {
   return (
-    <Breadcrumbs className='mb-4' size='lg'>
+    // The current item is a whole post title, which is far wider than a phone
+    // screen. Let the trail wrap, and truncate the title itself, so a long
+    // title cannot push the page wider than the viewport.
+    <Breadcrumbs className='mb-4 max-w-full' size='lg' classNames={{ list: 'flex-wrap' }}>
       <BreadcrumbItem href='/'>Home</BreadcrumbItem>
       <BreadcrumbItem href='/blogs'>Blogs</BreadcrumbItem>
-      <BreadcrumbItem isCurrent>{title}</BreadcrumbItem>
+      {/* min-w-0 on the item: as a flex child it defaults to min-width:auto and
+          refuses to shrink below its text, so the wrap below never engages. */}
+      <BreadcrumbItem
+        isCurrent
+        classNames={{ base: 'min-w-0', item: 'whitespace-normal break-words' }}
+      >
+        {title}
+      </BreadcrumbItem>
     </Breadcrumbs>
   )
 }

--- a/app/components/BlogPostCardComponent.tsx
+++ b/app/components/BlogPostCardComponent.tsx
@@ -29,7 +29,7 @@ const BlogPostCardComponent = (props: Props) => {
       radius={"lg"}
       isHoverable
       isPressable
-      className="h-fit w-full transition-all duration-300 ease-in-out hover:scale-105"
+      className="h-full w-full transition-all duration-300 ease-in-out hover:scale-105"
       onPress={() => router.push(`/blogs/post/${props.id}`)}
       >
         <CardBody className=" flex flex-col gap-4 overflow-visible p-0">
@@ -37,7 +37,7 @@ const BlogPostCardComponent = (props: Props) => {
                 <Image
                 alt={props.id}
                 src={props.headerImageUrl}
-                className="w-full h-40 object-cover shadow-medium shadow-black/5"
+                className="w-full aspect-[40/21] object-cover shadow-medium shadow-black/5"
                 width={0}
                 height={0}
                 sizes="100vw"
@@ -49,8 +49,8 @@ const BlogPostCardComponent = (props: Props) => {
         authorName={props.authorName}
         date={props.date}
         />
-        <h4 className="text-foreground/90 font-bold text-lg truncate mt-2">{props.title}</h4>
-        <p className="text-md font-medium text-foreground/60 truncate">
+        <h4 className="text-foreground/90 font-bold text-lg line-clamp-2 mt-2">{props.title}</h4>
+        <p className="text-md font-medium text-foreground/60 line-clamp-2">
           {props.description}
         </p>
       </div>

--- a/app/components/HeroComponent.tsx
+++ b/app/components/HeroComponent.tsx
@@ -29,11 +29,16 @@ const skills = [
 
 export default function HeroComponent() {
   return (
-    <section className="flex flex-row justify-center items-center gap-16 py-24 px-8 max-sm:py-8 w-full max-sm:flex-col">
-      <div className="hidden flex-row m-auto items-center max-sm:flex">
-      <AvatarComponent height={200} width={200} src={avatarImage} placeholder="blur"/>
+    // Side-by-side only once there is genuinely room for it. The text column is
+    // ~710px wide at its natural size and the avatar block another ~264px, so
+    // below xl the two are stacked. Laying them out in a row any earlier
+    // overflowed a `justify-center` container, which pushes content off the
+    // left edge where it cannot be scrolled back into view.
+    <section className="flex flex-col xl:flex-row justify-center items-center gap-12 xl:gap-16 py-16 xl:py-24 max-sm:py-8 px-8 w-full">
+      <div className="flex shrink-0 xl:order-2 xl:px-8">
+        <AvatarComponent height={200} width={200} src={avatarImage} placeholder="blur"/>
       </div>
-      <div className="flex flex-col gap-4 items-start">
+      <div className="flex flex-col gap-4 items-start xl:order-1">
         <p className="font-regular text-6xl uppercase text-foreground-500">
           Hello,
         </p>
@@ -47,7 +52,7 @@ export default function HeroComponent() {
           I&apos;m a Software Engineer who loves making modern Android & Web
           apps.
         </p>
-        <div className="flex flex-row gap-8 pt-4 max-sm:flex-col items-start">
+        <div className="flex flex-row flex-wrap gap-x-8 gap-y-4 pt-4 max-sm:flex-col items-start">
           {skills.map((skill, index) => (
             <div
               className="flex flex-row gap-2 item-center justify-center"
@@ -60,9 +65,6 @@ export default function HeroComponent() {
             </div>
           ))}
         </div>
-      </div>
-      <div className="px-8 flex max-w-fit flex-row items-center max-sm:hidden">
-        <AvatarComponent height={200} width={200} src={avatarImage} placeholder="blur"/>
       </div>
     </section>
   );

--- a/app/components/ProjectComponent.tsx
+++ b/app/components/ProjectComponent.tsx
@@ -17,7 +17,7 @@ export default function ProjectComponent() {
     <section className="flex flex-col gap-8 p-8 w-full justify-center items-center">
        <p className="text-4xl font-bold my-8">Projects</p>
 
-      <div className="grid grid-cols-2 gap-8 max-sm:grid-cols-1">
+      <div className="grid w-full max-w-[1536px] grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-8">
         {projects.map((project, index) => (
           <Card
             key={`${project.name}+${index}`}
@@ -25,7 +25,7 @@ export default function ProjectComponent() {
             radius={"lg"}
             isHoverable
             isPressable
-            className="p-unit-md max-w-unit-9xl border dark:border-zinc-700 bg-linear-to-tr from-neutral-200 to-neutral-50 dark:bg-linear-to-tr dark:from-black dark:to-zinc-900 min-w-unit-lg transition hover:-translate-x-1 hover:-translate-y-1"
+            className="h-full border dark:border-zinc-700 bg-linear-to-tr from-neutral-200 to-neutral-50 dark:bg-linear-to-tr dark:from-black dark:to-zinc-900 transition hover:-translate-x-1 hover:-translate-y-1"
             onPress={() => window.open(project.link, "_blank")}
           >
             <CardHeader className="flex flex-row gap-4">
@@ -38,7 +38,7 @@ export default function ProjectComponent() {
                   />
               <p className="text-2xl font-medium">{project.name}</p>
             </CardHeader>
-            <CardBody>
+            <CardBody className="grow">
               <p className="text-md text-foreground-500 font-normal">{project.description}</p>
             </CardBody>
             <CardFooter className="flex flex-wrap gap-2">

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -9,7 +9,7 @@ import resumePage2 from "@/public/images/shubham-singh-resume-page2.jpg";
 export default function AboutPage() {
   return (
     <section className="flex min-h-screen flex-col gap-8 p-8 w-full items-center">
-      <div className="flex flex-row w-4/6 max-sm:w-full m-8 justify-between">
+      <div className="flex flex-row w-4/6 max-sm:w-full max-w-4xl m-8 justify-between">
         <p className="text-4xl font-bold">Resume</p>
         <Button
           variant={"shadow"}
@@ -27,13 +27,13 @@ export default function AboutPage() {
           src={resumePage1}
           alt="Shubham Singh resume page 1"
           placeholder={"blur"}
-          className={"w-4/6 h-auto m-auto max-sm:w-full rounded-xl md:rounded-2xl lg:rounded-3xl"}
+          className={"w-4/6 h-auto m-auto max-w-4xl max-sm:w-full rounded-xl md:rounded-2xl lg:rounded-3xl"}
         />
         <NextImage
           src={resumePage2}
           alt="Shubham Singh resume page 2"
           placeholder={"blur"}
-          className={"w-4/6 h-auto m-auto max-sm:w-full rounded-xl md:rounded-2xl lg:rounded-b-3xl"}
+          className={"w-4/6 h-auto m-auto max-w-4xl max-sm:w-full rounded-xl md:rounded-2xl lg:rounded-b-3xl"}
         />
       </div>
     </section>

--- a/app/uses/page.tsx
+++ b/app/uses/page.tsx
@@ -9,12 +9,12 @@ import { Card, Chip, Link } from "@heroui/react";
 export default function UsesPage() {
   return (
     <section className="flex min-h-screen flex-col gap-8 p-8 w-full items-center">
-      <div className="flex flex-col w-4/6 max-sm:w-full m-8 gap-8 justify-between items-start">
+      <div className="flex flex-col w-4/6 max-sm:w-full max-w-[1536px] m-8 gap-8 justify-between items-start">
         <div className="flex flex-col gap-2 w-full items-start m-auto">
           <h1 className={"text-foreground/90 font-extrabold text-3xl mb-1"}>
             Uses
           </h1>
-          <h3 className={"text-foreground/80 font-medium text-xl mb-4"}>
+          <h3 className={"text-foreground/80 font-medium text-xl mb-4 max-w-3xl"}>
             This is a{" "}
             {
               <Link
@@ -47,7 +47,7 @@ export default function UsesPage() {
         return (
           <div
             key={type}
-            className="flex flex-col gap-12 w-4/6 max-sm:w-full m-8 justify-between items-start"
+            className="flex flex-col gap-12 w-4/6 max-sm:w-full max-w-[1536px] m-8 justify-between items-start"
           >
             <p className="text-4xl font-bold text-start">{type}</p>
             <div


### PR DESCRIPTION
Layout fixes for large screens and mobile, found while checking the ScaleBridge post (#66) at fullscreen.

## Root cause

Four HeroUI v1 `unit` utilities do not exist under HeroUI v2 + Tailwind v4, and were silently resolving to nothing:

| Class | Where | Computed to |
| --- | --- | --- |
| `max-w-unit-9xl` | project card | `max-width: none` |
| `min-w-unit-lg` | project card | `min-width: auto` |
| `p-unit-md` | project card | `padding: 0px` |
| `max-w-unit-6xl` | blog search input | `max-width: none` |

The project cards were written to have a max width. It has never applied.

## Measured at 2560px

| | Before | After |
| --- | --- | --- |
| Project card | 1225x166 (7.4:1) | 491x286 (1.7:1) |
| Project description | 150 chars/line | 58 |
| About paragraph | 87 chars/line | 56 |
| Post prose | ~138 chars/line | 78 |
| Blog card banner visible | 57% | 100% |
| Resume page image | 1664px | 896px, aligned to its header |

Content caps at 1536px. Projects go to three columns at `xl`, with equal-height cards and the tech chips on a shared baseline.

## Two bugs found along the way

**The hero clipped itself off-screen.** Between roughly 640px and 1100px the text column sat at `left: -40px`, which cannot be scrolled back into view — `flex-row` plus `justify-center` overflows in both directions. It now stacks below `xl` and goes side-by-side above, where there is measurably room: 1148px of content in a 1280px viewport, 58px clear on each side. The two duplicated avatar blocks are collapsed into one, reordered with `xl:order-2`.

**Mobile post padding was doubled.** The section and the markdown wrapper each applied `p-8`, giving phones 64px of padding per side.

## Mobile

- Screenshots cap at `min(px, 100%)`. A bare pixel cap is wider than a phone viewport and spilled past the right edge.
- The breadcrumb wraps, with `min-w-0` on the current item so it can shrink below its text. A flex child defaults to `min-width: auto` and otherwise refuses to.
- Post-page horizontal overflow goes from **88px to 0**.

## Verification

Checked at 375, 974, 1279, 1280, 1440 and 2560 across home, blogs, post, resume and uses. Zero horizontal overflow at every width, and `npm run build` passes with all routes prerendering.

## Not addressed

`/blogs` logs a pre-existing hydration mismatch on the HeroUI search input (react-aria generating different ids on server vs client), plus two 404s I did not chase down. Both predate these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)